### PR TITLE
fix: correct VERSION file path in release-manager

### DIFF
--- a/tools/release-manager/main.go
+++ b/tools/release-manager/main.go
@@ -73,8 +73,8 @@ func checkLabels(labelsJSON string) {
 }
 
 func bumpVersion(releaseType string) {
-	// Read current version
-	versionBytes, err := os.ReadFile("VERSION")
+	// Read current version from project root
+	versionBytes, err := os.ReadFile("../../VERSION")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading VERSION file: %v\n", err)
 		os.Exit(1)
@@ -131,8 +131,8 @@ func bumpVersion(releaseType string) {
 
 	fmt.Printf("New version: %s\n", newVersion)
 
-	// Write new version
-	if err := os.WriteFile("VERSION", []byte(newVersion), 0644); err != nil {
+	// Write new version to project root
+	if err := os.WriteFile("../../VERSION", []byte(newVersion), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing VERSION file: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## 🐛 Problem

The auto-release workflow was failing at the 'Bump version' step with:


## 🔍 Root Cause

The  tool was looking for the  file in the wrong location:
- **Workflow runs**: `cd tools/release-manager` then `./release-manager bump-version "patch"`
- **Tool expected**: `VERSION` in current directory (`tools/release-manager/`)
- **Actual location**: `VERSION` in project root

## ✅ Solution

Updated  to use correct relative paths:
- **Read**: `../../VERSION` (from tools/release-manager/ to project root)
- **Write**: `../../VERSION` (same path for writing updates)

## 🧪 Testing

This fixes the auto-release workflow failures. PRs with `release:patch` labels should now:
1. ✅ Detect release labels
2. ✅ Bump version in VERSION file  
3. ✅ Create git tag
4. ✅ Create GitHub Release

## 🎯 Impact

- Fixes broken auto-release automation
- Enables proper version bumping (0.1.1 → 0.1.2)
- Unblocks GitHub Release creation for tagged PRs

**Label**: `release:patch` - This is a critical fix for release automation