### PR TITLE
fix: update CI scripts to use GITHUB_BASE_SHA consistently (CRITICAL)

### DIFF
--- a/.github/scripts/ci/check-formatting.sh
+++ b/.github/scripts/ci/check-formatting.sh
@@ -8,11 +8,13 @@ fi
 
 echo "[CHECK] Checking Go code formatting..."
 
-# Get list of changed Go files in this PR
-if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+# Get list of changed Go files
+if [ -n "$GITHUB_BASE_SHA" ]; then
     CHANGED_GO_FILES=$(git diff --name-only $GITHUB_BASE_SHA..HEAD | grep '\.go$' || true)
+    echo "Checking changed files since $GITHUB_BASE_SHA"
 else
     CHANGED_GO_FILES=$(find . -name "*.go")
+    echo "No base SHA available - checking all Go files"
 fi
 
 if [ -n "$CHANGED_GO_FILES" ]; then

--- a/.github/scripts/ci/run-linting.sh
+++ b/.github/scripts/ci/run-linting.sh
@@ -9,10 +9,12 @@ fi
 echo "[LINT] Running Go linting..."
 
 # Get list of changed Go files
-if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+if [ -n "$GITHUB_BASE_SHA" ]; then
     CHANGED_GO_FILES=$(git diff --name-only $GITHUB_BASE_SHA..HEAD | grep '\.go$' || true)
+    echo "Checking changed files since $GITHUB_BASE_SHA"
 else
     CHANGED_GO_FILES=$(find . -name "*.go")
+    echo "No base SHA available - checking all Go files"
 fi
 
 # Track if we found any blocking issues in changed files


### PR DESCRIPTION
CRITICAL CI Fix: This addresses the actual root cause of CI inconsistency.

The issue was not just the GITHUB_BASE_SHA environment variable, but the hardcoded script logic that completely ignored it on main branch.

Before: Scripts used git diff for PRs but find . for main branch pushes
After: Scripts use git diff with GITHUB_BASE_SHA for both contexts

This ensures truly consistent behavior between PR and main branch.