### PR TITLE
Add micro-benchmarks for codegen, macro, analyzer, and package resolver

### DIFF
--- a/internal/transpiler/analysis/benchmarks_test.go
+++ b/internal/transpiler/analysis/benchmarks_test.go
@@ -1,0 +1,51 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/thsfranca/vex/internal/transpiler/parser"
+)
+
+func parseProgram(src string) *parser.ProgramContext {
+    input := antlr.NewInputStream(src)
+    lex := parser.NewVexLexer(input)
+    tokens := antlr.NewCommonTokenStream(lex, 0)
+    p := parser.NewVexParser(tokens)
+    return p.Program().(*parser.ProgramContext)
+}
+
+type astAdapter struct{ prog *parser.ProgramContext }
+
+func (a *astAdapter) Accept(v ASTVisitor) error { return v.VisitProgram(a.prog) }
+
+func BenchmarkAnalyzer_Simple(b *testing.B) {
+    src := "(def x 1) (+ x 2)"
+    prog := parseProgram(src)
+    ast := &astAdapter{prog: prog}
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        a := NewAnalyzer()
+        if _, err := a.Analyze(ast); err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+func BenchmarkAnalyzer_Mixed(b *testing.B) {
+    // Keep analyzer happy: avoid undefined symbols by not calling functions
+    src := "(def a 10) (def b 20) (if (> a 0) a b)"
+    prog := parseProgram(src)
+    ast := &astAdapter{prog: prog}
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        a := NewAnalyzer()
+        if _, err := a.Analyze(ast); err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+

--- a/internal/transpiler/codegen/benchmarks_test.go
+++ b/internal/transpiler/codegen/benchmarks_test.go
@@ -1,0 +1,79 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/thsfranca/vex/internal/transpiler/parser"
+)
+
+// benchAST adapts a parsed ProgramContext to the local AST interface.
+type benchAST struct{ prog *parser.ProgramContext }
+
+func (a *benchAST) Accept(v ASTVisitor) error { return v.VisitProgram(a.prog) }
+
+// stubSymbols satisfies SymbolTable; generator does not depend on it.
+type stubSymbols struct{}
+
+func (s *stubSymbols) Define(name string, value Value) error { return nil }
+func (s *stubSymbols) Lookup(name string) (Value, bool) { return nil, false }
+func (s *stubSymbols) EnterScope()                     {}
+func (s *stubSymbols) ExitScope()                      {}
+
+func parseProgramBench(src string) *parser.ProgramContext {
+    input := antlr.NewInputStream(src)
+    lex := parser.NewVexLexer(input)
+    tokens := antlr.NewCommonTokenStream(lex, 0)
+    p := parser.NewVexParser(tokens)
+    return p.Program().(*parser.ProgramContext)
+}
+
+func BenchmarkCodegen_Simple(b *testing.B) {
+    src := "(def x 42)\n(fmt/Println x)"
+    prog := parseProgramBench(src)
+    ast := &benchAST{prog: prog}
+    gen := NewGoCodeGenerator(Config{PackageName: "main", GenerateComments: false, IndentSize: 4})
+    syms := &stubSymbols{}
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _, err := gen.Generate(ast, syms)
+        if err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+func BenchmarkCodegen_NestedArithmetic(b *testing.B) {
+    src := "(+ (* 10 5) (- 20 (/ 100 5)))"
+    prog := parseProgramBench(src)
+    ast := &benchAST{prog: prog}
+    gen := NewGoCodeGenerator(Config{PackageName: "main", GenerateComments: false, IndentSize: 4})
+    syms := &stubSymbols{}
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _, err := gen.Generate(ast, syms)
+        if err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+func BenchmarkCodegen_ImportsAndAliases(b *testing.B) {
+    src := "(import [[\"net/http\" http] [\"encoding/json\" json]])\n(http/Get \"http://example.com\")\n(json/Marshal \"x\")"
+    prog := parseProgramBench(src)
+    ast := &benchAST{prog: prog}
+    gen := NewGoCodeGenerator(Config{PackageName: "main", GenerateComments: false, IndentSize: 4})
+    syms := &stubSymbols{}
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _, err := gen.Generate(ast, syms)
+        if err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+

--- a/internal/transpiler/macro/benchmarks_test.go
+++ b/internal/transpiler/macro/benchmarks_test.go
@@ -1,0 +1,35 @@
+package macro
+
+import "testing"
+
+func BenchmarkMacro_ExpandSimple(b *testing.B) {
+    r := NewRegistry(Config{EnableValidation: false})
+    _ = r.RegisterMacro("id", &Macro{Name: "id", Params: []string{"x"}, Body: "x"})
+    e := NewExpander(r)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        if _, err := e.ExpandMacro("id", []string{"42"}); err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+func BenchmarkMacro_ExpandChained(b *testing.B) {
+    r := NewRegistry(Config{EnableValidation: false})
+    _ = r.RegisterMacro("inc", &Macro{Name: "inc", Params: []string{"x"}, Body: "(+ x 1)"})
+    e := NewExpander(r)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        v1, err := e.ExpandMacro("inc", []string{"10"})
+        if err != nil {
+            b.Fatal(err)
+        }
+        if _, err := e.ExpandMacro("inc", []string{v1}); err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+

--- a/internal/transpiler/packages/benchmarks_test.go
+++ b/internal/transpiler/packages/benchmarks_test.go
@@ -1,0 +1,35 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkResolver_SmallProject(b *testing.B) {
+    // Use the repo's examples/valid/project-multi as a realistic small project
+    // From repo root one level up from this package dir
+    // Walk up until we find go.mod
+    dir, _ := os.Getwd()
+    for {
+        if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+            break
+        }
+        parent := filepath.Dir(dir)
+        if parent == dir {
+            b.Fatal("could not locate repository root")
+        }
+        dir = parent
+    }
+    entry := filepath.Join(dir, "examples/valid/project-multi/main.vx")
+    r := NewResolver(dir)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        if _, err := r.BuildProgramFromEntry(entry); err != nil {
+            b.Fatal(err)
+        }
+    }
+}
+
+


### PR DESCRIPTION
## Pull Request Checklist

**Brief description of changes:**
Adds missing performance benchmarks for core subsystems to improve visibility and guide optimizations:
- Codegen: simple, nested arithmetic, imports & aliases
- Macro: simple expansion and chained expansion
- Analysis: simple and mixed programs
- Packages: resolver benchmark over examples/valid/project-multi

### ✅ Requirements (Automatically Checked)
- [x] All tests pass locally
- [x] Code builds successfully
- [x] Examples continue to parse
- Coverage impact: test-only additions; transpiler coverage threshold unaffected

### 📝 Manual Checklist
- [x] Added tests (benchmarks)
- [x] Follows project patterns
- [x] No breaking changes

No grammar or CI/tooling changes in this PR. Establishes baseline ns/op and allocs/op for targeted areas.
